### PR TITLE
Add an optional imagej.app.subdirectory property

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ It provides one goal:
   artifact and all its dependencies into an _ImageJ.app/_ directory structure;
   ImageJ 1.x plugins (identified by containing a _plugins.config_ file) get
   copied to the _plugins/_ subdirectory and all other _.jar_ files to _jars/_.
-  It expects the location of the _ImageJ.app/_ directory to be specified in the
-  property _imagej.app.directory_ (which can be set on the Maven command-line).
-  If said property is not set, the __copy-jars__ goal is skipped.
+  However, you can override this decision by setting the property
+  _imagej.app.subdirectory_ to a specific subdirectory. It expects the location
+  of the _ImageJ.app/_ directory to be specified in the property
+  _imagej.app.directory_ (which can be set on the Maven command-line). If said
+  property is not set, the __copy-jars__ goal is skipped.
 
 It is recommended to use it implicitly by making the
 [SciJava POM](https://github.com/scijava/pom-scijava) the parent project:

--- a/src/it/copy-to-subdirectory/pom.xml
+++ b/src/it/copy-to-subdirectory/pom.xml
@@ -1,0 +1,73 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test imagej-maven-plugin's CopyJarsMojo</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.app.subdirectory>plugins/Test/Directory/</imagej.app.subdirectory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>net.imagej</groupId>
+				<artifactId>imagej-maven-plugin</artifactId>
+				<version>${imagej-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/copy-to-subdirectory/setup.bsh
+++ b/src/it/copy-to-subdirectory/setup.bsh
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();

--- a/src/it/copy-to-subdirectory/src/main/resources/plugins.config
+++ b/src/it/copy-to-subdirectory/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/copy-to-subdirectory/verify.bsh
+++ b/src/it/copy-to-subdirectory/verify.bsh
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+subdirectory = new File(plugins, "Test/Directory/");
+assertTrue("Should exist: " + subdirectory, subdirectory.exists());
+jar = new File(subdirectory, "Example_PlugIn-1.0.0-SNAPSHOT.jar");
+assertTrue("Should exist: " + jar, jar.exists());

--- a/src/it/delete-other-versions-in-subdirectory/pom.xml
+++ b/src/it/delete-other-versions-in-subdirectory/pom.xml
@@ -1,0 +1,68 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test imagej-maven-plugin's CopyJarsMojo</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.app.subdirectory>plugins/Test2/</imagej.app.subdirectory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>net.imagej</groupId>
+				<artifactId>imagej-maven-plugin</artifactId>
+				<version>${imagej-maven.version}</version>
+				<configuration>
+					<deleteOtherVersions>true</deleteOtherVersions>
+				</configuration>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/delete-other-versions-in-subdirectory/setup.bsh
+++ b/src/it/delete-other-versions-in-subdirectory/setup.bsh
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();
+subdir = new File(plugins, "Test");
+subdir.mkdirs();
+
+subdir2 = new File(plugins, "Test2");
+subdir2.mkdirs();
+
+touchFile(new File(subdir, "Example_PlugIn-0.9.0-obsolete.jar"));

--- a/src/it/delete-other-versions-in-subdirectory/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-in-subdirectory/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/delete-other-versions-in-subdirectory/verify.bsh
+++ b/src/it/delete-other-versions-in-subdirectory/verify.bsh
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+testSubdir = new File(plugins, "Test/");
+obsolete = new File(testSubdir, "Example_PlugIn-0.9.0-obsolete.jar");
+assertTrue("Should not exist: " + obsolete, !obsolete.exists());
+
+testSubdir2 = new File(plugins, "Test2");
+jar = new File(testSubdir2, "Example_PlugIn-1.0.0-SNAPSHOT.jar");
+assertTrue("Should exist: " + jar, jar.exists());

--- a/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
+++ b/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
@@ -67,6 +67,7 @@ import org.codehaus.plexus.util.FileUtils;
 public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 
 	public static final String imagejDirectoryProperty = "imagej.app.directory";
+	public static final String imagejSubdirectoryProperty = "imagej.app.subdirectory";
 	public static final String deleteOtherVersionsProperty = "delete.other.versions";
 
 	protected boolean hasIJ1Dependency(final MavenProject project) {
@@ -126,12 +127,21 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 		final File imagejDirectory, final boolean force,
 		final boolean deleteOtherVersions) throws IOException
 	{
+		installArtifact(artifact, imagejDirectory, "", force, deleteOtherVersions);
+	}
+
+	protected void installArtifact(final Artifact artifact,
+		final File imagejDirectory, final String subdirectory, final boolean force,
+		final boolean deleteOtherVersions) throws IOException
+	{
 		if (!"jar".equals(artifact.getType())) return;
 
 		final File source = artifact.getFile();
 		final File targetDirectory;
 
-		if (isIJ1Plugin(source)) {
+		if (subdirectory != null && !subdirectory.equals("")) {
+			targetDirectory = new File(imagejDirectory, subdirectory);
+		} else if (isIJ1Plugin(source)) {
 			targetDirectory = new File(imagejDirectory, "plugins");
 		}
 		else if ("ome".equals(artifact.getGroupId()) ||

--- a/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
+++ b/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
@@ -32,8 +32,10 @@
 package net.imagej.maven;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,6 +44,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
@@ -169,18 +172,18 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 			FileUtils.copyFile(source, target);
 		}
 
-		final Collection<File> otherVersions = getEncroachingVersions(target);
+		final Collection<Path> otherVersions = getEncroachingVersions(Paths.get(imagejDirectory.toURI()), Paths.get(target.toURI()));
 		if (otherVersions != null && !otherVersions.isEmpty()) {
-			for (final File file : otherVersions) {
+			for (final Path file : otherVersions) {
 				if (!deleteOtherVersions) {
 					getLog().warn(
-						"Possibly incompatible version exists: " + file.getName());
+						"Possibly incompatible version exists: " + file.getFileName());
 				}
-				else if (file.delete()) {
-					getLog().info("Deleted overridden " + file.getName());
+				else if (Files.deleteIfExists(file)) {
+					getLog().info("Deleted overridden " + file.getFileName());
 				}
 				else {
-					getLog().warn("Could not delete overridden " + file.getName());
+					getLog().warn("Could not delete overridden " + file.getFileName());
 				}
 			}
 		}
@@ -213,33 +216,41 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 	private final static int PREFIX_INDEX = 1;
 	private final static int SUFFIX_INDEX = 5;
 
-	private static Collection<File> getEncroachingVersions(final File file) {
-		// TODO reuse FileUtils.stripFilenameVersion logic
-		final Matcher matcher = versionPattern.matcher(file.getName());
+	/**
+	 * Looks for files in {@code directory} with the same base name as
+	 * {@code file}.
+	 *
+	 * @param directory The directory to walk to find possible duplicates.
+	 * @param file A {@link Path} to the target (from which the base name is
+	 *          derived).
+	 * @return A collection of {@link Path}s to files of the same base name.
+	 */
+	private Collection<Path> getEncroachingVersions(final Path directory, final Path file) {
+		final Matcher matcher = versionPattern.matcher(file.getFileName().toString());
 		if (!matcher.matches()) return null;
 
 		final String prefix = matcher.group(PREFIX_INDEX);
 		final String suffix = matcher.group(SUFFIX_INDEX);
-		final File parent = file.getParentFile();
-		final File directory =
-			parent != null ? parent : file.getAbsoluteFile().getParentFile();
-		if (directory == null) return null;
-		final File[] candidates = directory.listFiles(new FilenameFilter() {
 
-			public boolean accept(File dir, String name) {
-				if (!name.startsWith(prefix)) return false;
-				final Matcher matcher = versionPattern.matcher(name);
-				return matcher.matches() &&
-					prefix.equals(matcher.group(PREFIX_INDEX)) &&
-					suffix.equals(matcher.group(SUFFIX_INDEX));
-			}
-		});
-		if (candidates == null || candidates.length == (file.exists() ? 1 : 0)) return null;
-
-		final Collection<File> result = new ArrayList<File>();
-		for (final File candidate : candidates) {
-			if (!candidate.equals(file)) result.add(candidate);
+		Collection<Path> result = new ArrayList<>();
+		try {
+			result = Files.walk(directory)
+			.filter(path -> path.getFileName().toString().startsWith(prefix))
+			.filter(path -> {
+				final Matcher matcherIterator = versionPattern.matcher(path.getFileName().toString());
+				return matcherIterator.matches() &&
+					prefix.equals(matcherIterator.group(PREFIX_INDEX)) &&
+					suffix.equals(matcherIterator.group(SUFFIX_INDEX));
+			})
+			.filter(path -> !path.getFileName().toString().equals(file.getFileName().toString()))
+			.collect(Collectors.toCollection(ArrayList::new));
+			return result;
+		} catch (IOException e) {
+			getLog().error(e);
+		} finally {
+			result = new ArrayList<>();
 		}
+
 		return result;
 	}
 }

--- a/src/main/java/net/imagej/maven/CopyJarsMojo.java
+++ b/src/main/java/net/imagej/maven/CopyJarsMojo.java
@@ -69,6 +69,16 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 	private String imagejDirectory;
 
 	/**
+	 * The name of the property pointing to the subdirectory (beneath e.g.
+	 * {@code jars/} or {@code plugins/}) to which the artifact should be copied.
+	 * <p>
+	 * If no property of that name exists, no subdirectory will be used.
+	 * </p>
+	 */
+	@Parameter(property = imagejSubdirectoryProperty, required = false)
+	private String imagejSubdirectory;
+
+	/**
 	 * Whether to delete other versions when copying the files.
 	 * <p>
 	 * When copying a file and its dependencies to an ImageJ.app/ directory and
@@ -110,6 +120,12 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 		}
 		final String interpolated = interpolate(imagejDirectory, project, session);
 		imagejDir = new File(interpolated);
+
+		if (imagejSubdirectory == null) {
+			getLog().info("No property name for the " + imagejSubdirectoryProperty +
+				" directory location was specified; Installing in default location");
+		}
+
 		if (!imagejDir.isDirectory()) {
 			getLog().warn(
 				"'" + imagejDirectory + "'" +
@@ -133,6 +149,11 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 					.resolveDependencies(buildingRequest, coordinate, scopeFilter);
 				for (ArtifactResult result : resolveDependencies) {
 					try {
+						if (project.getArtifact().equals(result.getArtifact())) {
+							installArtifact(result.getArtifact(), imagejDir, imagejSubdirectory, false,
+								deleteOtherVersions);
+							continue;
+						}
 						installArtifact(result.getArtifact(), imagejDir, false, deleteOtherVersions);
 					}
 					catch (IOException e) {


### PR DESCRIPTION
This enables users to have their plugins copied to a subfolder of ImageJ's jars or plugins.

Continuation of #17.