### PR TITLE
Add imagej.app.subdirectory property for install-artifact

### DIFF
--- a/src/it/copy-to-subdirectory/pom.xml
+++ b/src/it/copy-to-subdirectory/pom.xml
@@ -66,6 +66,18 @@
 							<goal>copy-jars</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<imagejSubdirectory>jars/Subdirectory/</imagejSubdirectory>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/src/it/copy-to-subdirectory/verify.bsh
+++ b/src/it/copy-to-subdirectory/verify.bsh
@@ -34,3 +34,6 @@ subdirectory = new File(plugins, "Test/Directory/");
 assertTrue("Should exist: " + subdirectory, subdirectory.exists());
 jar = new File(subdirectory, "Example_PlugIn-1.0.0-SNAPSHOT.jar");
 assertTrue("Should exist: " + jar, jar.exists());
+
+subdirectoryPlugin = new File(ijDir, "../Other.app/jars/Subdirectory/Example_PlugIn-1.0.0-SNAPSHOT.jar");
+assertTrue("Should exist: " + subdirectoryPlugin, subdirectoryPlugin.exists());


### PR DESCRIPTION
Somehow, adding the `imagej.app.subdirectory` property to `install-artifact` had slipped our attention in #22.