### PR TITLE
Add imagej.ignoreDependencies property

### DIFF
--- a/src/it/ignore-dependencies/pom.xml
+++ b/src/it/ignore-dependencies/pom.xml
@@ -1,0 +1,85 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to test ignoring dependencies</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.ignoreDependencies>true</imagej.ignoreDependencies>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>net.imagej</groupId>
+				<artifactId>imagej-maven-plugin</artifactId>
+				<version>${imagej-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+							<ignoreDependencies>true</ignoreDependencies>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/ignore-dependencies/setup.bsh
+++ b/src/it/ignore-dependencies/setup.bsh
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();

--- a/src/it/ignore-dependencies/src/main/resources/plugins.config
+++ b/src/it/ignore-dependencies/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+Example, "Plug In", Example_PlugIn

--- a/src/it/ignore-dependencies/verify.bsh
+++ b/src/it/ignore-dependencies/verify.bsh
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should exist: " + plugin, plugin.exists());
+
+ij = new File(ijDir, "jars/ij-1.48s.jar");
+assertTrue("Should not exist: " + ij, !ij.exists());
+
+otherIJ = new File(ijDir, "../Other.app/jars/ij-1.48s.jar");
+assertTrue("Should not exist: " + otherIJ, !otherIJ.exists());

--- a/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
+++ b/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
@@ -74,6 +74,7 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 	public static final String imagejSubdirectoryProperty = "imagej.app.subdirectory";
 	public static final String deleteOtherVersionsProperty = "delete.other.versions";
 	public static final String deleteOtherVersionsPolicyProperty = "imagej.deleteOtherVersions";
+	public static final String ignoreDependenciesProperty = "imagej.ignoreDependencies";
 
 	public enum OtherVersions {
 			always, older, never

--- a/src/main/java/net/imagej/maven/CopyJarsMojo.java
+++ b/src/main/java/net/imagej/maven/CopyJarsMojo.java
@@ -128,7 +128,10 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 
 	@Parameter( defaultValue = "${mojoExecution}", readonly = true )
 	MojoExecution mojoExecution;
-	
+
+	@Parameter(property = ignoreDependenciesProperty, defaultValue = "false")
+	private boolean ignoreDependencies;
+
 	@Override
 	public void execute() throws MojoExecutionException {
 		// Keep backwards compatibility to delete.other.versions
@@ -172,7 +175,7 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 
 		try {
 			TransformableFilter scopeFilter = ScopeFilter.excluding("system", "provided", "test");
-			
+
 			ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
 			buildingRequest.setProject( project );
 
@@ -185,7 +188,8 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 								deleteOtherVersionsPolicy);
 							continue;
 						}
-						installArtifact(result.getArtifact(), imagejDir, false, deleteOtherVersionsPolicy);
+						if ( !ignoreDependencies )
+							installArtifact( result.getArtifact(), imagejDir, false, deleteOtherVersionsPolicy );
 					}
 					catch (IOException e) {
 						throw new MojoExecutionException("Couldn't download artifact " +

--- a/src/main/java/net/imagej/maven/InstallArtifactMojo.java
+++ b/src/main/java/net/imagej/maven/InstallArtifactMojo.java
@@ -221,6 +221,9 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 	@Parameter( defaultValue = "${mojoExecution}", readonly = true )
 	MojoExecution mojoExecution;
 
+	@Parameter(property = ignoreDependenciesProperty, defaultValue = "false")
+	private boolean ignoreDependencies;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		// Keep backwards compatibility to delete.other.versions
@@ -313,8 +316,8 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 						installArtifact( result.getArtifact(), imagejDir, imagejSubdirectory, false, deleteOtherVersionsPolicy );
 						continue;
 					}
-					installArtifact(result.getArtifact(), imagejDir, false,
-						deleteOtherVersionsPolicy);
+					if ( !ignoreDependencies )
+						installArtifact( result.getArtifact(), imagejDir, false, deleteOtherVersionsPolicy );
 				}
 				catch (IOException e) {
 					throw new MojoExecutionException("Couldn't download artifact " +


### PR DESCRIPTION
The `imagej.ignoreDependencies` property allows to only install the artifact itself into an app directory instead of the artifact together with its dependencies.