### PR TITLE
Add some defensive logic around version matching

### DIFF
--- a/src/it/handle-missing-version-numbers/pom.xml
+++ b/src/it/handle-missing-version-numbers/pom.xml
@@ -1,0 +1,65 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>missing-version-number</artifactId>
+	<version>1.0.0</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to test support for missing version numbers</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.deleteOtherVersions>older</imagej.deleteOtherVersions>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>net.imagej</groupId>
+				<artifactId>imagej-maven-plugin</artifactId>
+				<version>${imagej-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/handle-missing-version-numbers/setup.bsh
+++ b/src/it/handle-missing-version-numbers/setup.bsh
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+jars = new File(ijDir, "jars");
+if (!jars.exists()) jars.mkdirs();
+touchFile(new File(jars, "missing-version-number.jar"));

--- a/src/it/handle-missing-version-numbers/verify.bsh
+++ b/src/it/handle-missing-version-numbers/verify.bsh
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+jars = new File(ijDir, "jars");
+assertTrue("Has missing-version-number-1.0.0.jar",
+	!new File(jars, "missing-version-number-1.0.0.jar").exists());
+
+buildLog = readFile(new File(basedir, "build.log"));
+assertTrue("Should contain 'Impenetrable version suffix':\n" + buildLog,
+	buildLog.contains("Impenetrable version suffix"));

--- a/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
+++ b/src/main/java/net/imagej/maven/AbstractCopyJarsMojo.java
@@ -181,12 +181,22 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 						final String toInstall = artifact.getVersion();
 						final Matcher matcher = versionPattern.matcher(otherName.toString());
 						if (!matcher.matches()) break;
-						final String otherVersion = matcher.group(VERSION_INDEX).substring(1);
-						newerVersion = VersionUtils.compare(toInstall, otherVersion) < 0;
-						if (majorVersion(toInstall) != majorVersion(otherVersion))
-							getLog().warn("Found other version that is incompatible according to SemVer.");
-						if (newerVersion)
-							break;
+						final String group = matcher.group(VERSION_INDEX);
+						if (group == null) {
+							newerVersion = true;
+							getLog().warn("Impenetrable version suffix for file: " +
+								otherName);
+						}
+						else {
+							final String otherVersion = group.substring(1);
+							newerVersion = VersionUtils.compare(toInstall, otherVersion) < 0;
+							if (majorVersion(toInstall) != majorVersion(otherVersion)) {
+								getLog().warn(
+									"Found other version that is incompatible according to SemVer: " +
+										otherVersion);
+							}
+						}
+						if (newerVersion) break;
 						//$FALL-THROUGH$
 					case always:
 						if (Files.deleteIfExists(other)) {


### PR DESCRIPTION
Hopefully this avoids crashes like the one discussed in #31.

It would be good to know which JAR(s) failed to match the regex, so that the matching can be improved, but as a stopgap, this change may help us discern when such patterns are present in an installation, since it now emits the filenames of non-matching files.