### PR TITLE
CopyJarsMojo: respect project packaging

### DIFF
--- a/src/main/java/net/imagej/maven/CopyJarsMojo.java
+++ b/src/main/java/net/imagej/maven/CopyJarsMojo.java
@@ -169,6 +169,7 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 		coordinate.setGroupId(project.getGroupId());
 		coordinate.setArtifactId(project.getArtifactId());
 		coordinate.setVersion(project.getVersion());
+		coordinate.setType(project.getPackaging());
 
 		try {
 			TransformableFilter scopeFilter = ScopeFilter.excluding("system", "provided", "test");


### PR DESCRIPTION
Adds proper handling of project packaging s.t. multi-module POMs are resolved properly. The parent POM is not copied to `imagej.app.directory` after resolution.

Fixes #30.